### PR TITLE
Accounting for single value fields in entitymetadatawrapper on entityref...

### DIFF
--- a/src/Behat/SubContext/ContentContext.php
+++ b/src/Behat/SubContext/ContentContext.php
@@ -260,15 +260,12 @@ class ContentContext extends SubContext
       }
     }
     if (empty($fieldMachineName)) {
-      echo('empty $fieldMachineName');
       throw new \Exception("Entity property $fieldLabel doesn't exist.");
     }
     if ($subField) {
-      echo('subfield');
       $wrapper->$fieldMachineName->$subField = $value;
     }
     else {
-      echo('else');
       $wrapper->$fieldMachineName = $value;
     }
     $wrapper->save();


### PR DESCRIPTION
...erence fields when setting value.

If the cardinality is 1, entitymetadatawrapper expects a string rather than an array. I added logic for this on entityreference fields. I tried globally, but doing so broke other tests. At some point, we should probably look into how to best handle the cardinality issue when setting values.
