### PR TITLE
Task #977  crm_user cron	crm_user cron adds unwanted people to D7

### DIFF
--- a/src/Behat/SubContext/ContentContext.php
+++ b/src/Behat/SubContext/ContentContext.php
@@ -277,7 +277,11 @@ class ContentContext extends SubContext
   public function theShouldHaveValue($bundleLabel, $entityTypeLabel, $entityLabel, $fieldLabel, $rawValue) {
     $mainContext = $this->getMainContext();
     $wrappers = $mainContext->getSubcontext('DrupalContent')->content[$bundleLabel][$entityTypeLabel];
-    $this->checkValue($wrappers[$entityLabel], $fieldLabel, $rawValue);
+    // Refresh entity.
+    $id = $wrappers[$entityLabel]->getIdentifier();
+    $entity = entity_load($entityTypeLabel, array($id), array(), TRUE);
+    $wrapper = entity_metadata_wrapper($entityTypeLabel, $entity[$id]);
+    $this->checkValue($wrapper, $fieldLabel, $rawValue);
   }
 
   public function checkValue($wrapper, $fieldLabel, $rawValue) {


### PR DESCRIPTION
Added refreshing of entity before checking values. Because it was a cause of deprecated data on checking process.